### PR TITLE
fix: attach/detach edge cases and AI decomp running always

### DIFF
--- a/src/main/java/ai/reveng/toolkit/ghidra/binarysimilarity/ui/aidecompiler/AIDecompiledWindow.java
+++ b/src/main/java/ai/reveng/toolkit/ghidra/binarysimilarity/ui/aidecompiler/AIDecompiledWindow.java
@@ -10,6 +10,8 @@ import docking.action.DockingAction;
 import docking.action.ToolBarData;
 import docking.widgets.dialogs.InputDialog;
 import generic.theme.GIcon;
+import ghidra.Ghidra;
+import ghidra.app.services.ProgramManager;
 import ghidra.framework.plugintool.ComponentProviderAdapter;
 import ghidra.framework.plugintool.PluginTool;
 import ghidra.program.model.listing.Function;
@@ -39,6 +41,7 @@ public class AIDecompiledWindow extends ComponentProviderAdapter {
 
     public AIDecompiledWindow(PluginTool tool, String owner) {
         super(tool, ReaiPluginPackage.WINDOW_PREFIX + "AI Decompiler", owner);
+
         setIcon(ReaiPluginPackage.REVENG_16);
         component = buildComponent();
         addLocalAction(new DockingAction("Positive Feedback Action", getName()) {
@@ -49,8 +52,8 @@ public class AIDecompiledWindow extends ComponentProviderAdapter {
 
             @Override
             public void actionPerformed(ActionContext context) {
-                var service = tool.getService(GhidraRevengService.class);
                 if (function != null) {
+                    var service = tool.getService(GhidraRevengService.class);
                     var fID = service.getFunctionIDFor(function);
                     fID.ifPresent(id -> service.getApi().aiDecompRating(id, "POSITIVE", null));
                 }
@@ -78,8 +81,8 @@ public class AIDecompiledWindow extends ComponentProviderAdapter {
                 var dialog = new InputDialog("Negative Feedback", "Please provide details about what was wrong with the decompilation:", "");
                 tool.showDialog(dialog);
                 if (!dialog.isCanceled()) {
-                    var service = tool.getService(GhidraRevengService.class);
                     if (function != null) {
+                        var service = tool.getService(GhidraRevengService.class);
                         var fID = service.getFunctionIDFor(function);
                         fID.ifPresent(id -> service.getApi().aiDecompRating(id, "NEGATIVE", dialog.getValue()));
                     }
@@ -92,7 +95,6 @@ public class AIDecompiledWindow extends ComponentProviderAdapter {
                 return super.isEnabled();
             }
         });
-
     }
 
 
@@ -173,8 +175,9 @@ public class AIDecompiledWindow extends ComponentProviderAdapter {
         if (function != null && newFuncLocation != function) {
             clear();
         }
+
         function = newFuncLocation;
-        if (function != null) {
+        if (function != null && !function.isExternal() && !function.isThunk()) {
             refresh(function);
         }
     }

--- a/src/main/java/ai/reveng/toolkit/ghidra/binarysimilarity/ui/recentanalyses/RecentAnalysisDialog.java
+++ b/src/main/java/ai/reveng/toolkit/ghidra/binarysimilarity/ui/recentanalyses/RecentAnalysisDialog.java
@@ -84,7 +84,7 @@ public class RecentAnalysisDialog extends DialogComponentProvider {
         var service = tool.getService(GhidraRevengService.class);
         var analysisID = service.getApi().getAnalysisIDfromBinaryID(result.binary_id());
         var programWithID = new ProgramWithBinaryID(program, result.binary_id(), analysisID);
-        service.registerFinishedAnalysisForProgram(programWithID);
+
         tool.firePluginEvent(
                 new RevEngAIAnalysisStatusChangedEvent(
                         "Recent Analysis Dialog",

--- a/src/main/java/ai/reveng/toolkit/ghidra/plugins/AnalysisManagementPlugin.java
+++ b/src/main/java/ai/reveng/toolkit/ghidra/plugins/AnalysisManagementPlugin.java
@@ -213,7 +213,7 @@ public class AnalysisManagementPlugin extends ProgramPlugin {
 				.onAction(context -> {
 					var program = tool.getService(ProgramManager.class).getCurrentProgram();
 					var analysisID = this.revengService.getAnalysisIDFor(program);
-					var displayText = analysisID.map(id -> "analysis " + id.id());
+					var displayText = analysisID.map(id -> "analysis " + id.id()).get();
 
 					var result = OptionDialog.showOptionDialogWithCancelAsDefaultButton(
 							tool.getToolFrame(),

--- a/src/main/java/ai/reveng/toolkit/ghidra/plugins/BinarySimilarityPlugin.java
+++ b/src/main/java/ai/reveng/toolkit/ghidra/plugins/BinarySimilarityPlugin.java
@@ -78,9 +78,18 @@ public class BinarySimilarityPlugin extends ProgramPlugin {
 	@Override
 	protected void locationChanged(ProgramLocation loc) {
 		super.locationChanged(loc);
-        if (loc == null || loc.getProgram() == null) {
+
+        // If no location, nothing to do
+        if (loc == null) {
             return;
         }
+
+        // If no program, or not attached to an analysis, do not trigger location change events
+        var program = loc.getProgram();
+        if (program == null || !apiService.isKnownProgram(program)) {
+            return;
+        }
+
 		functionSimilarityComponent.locationChanged(loc);
 		decompiledWindow.locationChanged(loc);
 	}
@@ -183,6 +192,9 @@ public class BinarySimilarityPlugin extends ProgramPlugin {
 		new ActionBuilder("AI Decompilation", this.getName())
 				.withContext(ProgramLocationActionContext.class)
 				.enabledWhen(context -> {
+
+                    Msg.info(this, "here");
+
 					var func = context.getProgram().getFunctionManager().getFunctionContaining(context.getAddress());
 					return func != null
                             // Exclude thunks and external functions because we do not support them in the portal


### PR DESCRIPTION
This PR fixes issues with attach/detach causing double events which ended up in errors because of duplicate function maps.

Also fixed AI decomp trying to run even when we were detached from an analysis.